### PR TITLE
[fix] Gradle의 Toolchain 기능이 Java 17 감지하지 못하여 주석처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,11 +7,11 @@ plugins {
 group = 'com.ohgiraffers'
 version = '0.0.1-SNAPSHOT'
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
-    }
-}
+//java {
+//    toolchain {
+//        languageVersion = JavaLanguageVersion.of(17)
+//        vendor = JvmVendorSpec.AMAZON
+//}
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
toolchain 대신 현재 설치된 JDK로 직접 사용하도록 만들기